### PR TITLE
fix page exceeding border when a global zoom is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,5 +24,17 @@ What the extension different from others is that it gives a **tree-style list** 
 * Search: search all opened tabs by keyword.
 * Bookmarks: search your bookmarks and open the bookmark in a new tab quickly.
 
+### Build form source
+1. Clone the repository
+2. Execute `export NODE_OPTIONS=--openssl-legacy-provider` if you are using openssl 3.0 or newer
+3. Run `yarn install` to install dependencies
+4. Run `yarn run build` to build the extension
+5. Load the extension in Chrome/Edge:
+    * Open Chrome/Edge and go to `chrome://extensions/` or `edge://extensions/`
+    * Enable "Developer mode" (usually a toggle switch in the top right corner)
+    * Click "Load unpacked" (usually a button in the top left corner)
+    * Select the `build` folder in the project directory
+6. Pack into crx file if needed
+
 ### NOTICE
 Tabs which was opened before installing this extension could not be showed in a tree view.

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,13 @@ import TabTree from './components/tabTree';
 import Initializer from './util/initializer';
 import './index.css';
 
+// restore page zoom to 1 when user set a browser-wise global zoom
+// to prevent page from exceeding border
+chrome.tabs.getZoom(null, (zoomFactor) => {
+    const scale = 1 / zoomFactor;
+    document.documentElement.style.zoom = scale.toString(); 
+});
+
 ReactDOM.render(
     <TabTree
         chrome={chrome}


### PR DESCRIPTION
## Problem
If you set a browser-wise global zoom greater than 100%, the page will exceed the border and a horizonal scroll will show which is pretty inconevient for user.
<img width="1362" height="381" alt="pic" src="https://github.com/user-attachments/assets/d8270596-7f0e-44f2-b4e2-b8cffea0b5af" />
## Fix
- Restore page zoom to 100%
- Plus, add build steps to README