### PR TITLE
Enhance Ghost Browser identity management and tab filtering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ scripts/
 
 # production
 /build
+build.crx
+build.pem
 
 # misc
 .DS_Store

--- a/package-lock.json
+++ b/package-lock.json
@@ -19428,24 +19428,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/tailwindcss/node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
-    },
     "node_modules/tapable": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",

--- a/public/service_worker.js
+++ b/public/service_worker.js
@@ -5,6 +5,20 @@ const MAX_FREE_WORKSPACES = 3;
 
 const isNewTabUrl = (url) => NEW_TAB_URLS.includes(url);
 
+// Matches chrome://, edge://, about: pages and empty/null URLs.
+// Used to exclude system pages from the persistent hierarchy backup.
+const isSystemUrl = (url) => !url || /^(chrome|edge|about):/.test(url);
+
+// Normalise a URL for consistent hierarchy matching across sessions.
+// Strips fragments (client-side state) and, for non-http(s) URLs (internal
+// browser pages like ghost://extensions), strips trailing slashes so that
+// "ghost://extensions" and "ghost://extensions/" compare as equal.
+const normalizeUrl = (url) => {
+    if (!url) return url;
+    const noFrag = url.includes('#') ? url.slice(0, url.indexOf('#')) : url;
+    return /^https?:/.test(noFrag) ? noFrag : noFrag.replace(/\/$/, '');
+};
+
 // ============================================================
 // Workspace: multi-slot save/restore (max 3 in free tier)
 // ============================================================
@@ -38,6 +52,12 @@ async function saveWorkspace(name, marks = {}, notes = {}) {
         }
         if (notes[tab.id]) {
             entry.note = notes[tab.id];
+        }
+        if (tab.ghostPublicAPI?.identity_id) {
+            entry.ghostIdentityId = tab.ghostPublicAPI.identity_id;
+        }
+        if (tab.ghostPublicAPI?.workspace_id) {
+            entry.ghostWorkspaceId = tab.ghostPublicAPI.workspace_id;
         }
         entries.push(entry);
         idx++;
@@ -110,6 +130,7 @@ async function getWorkspacePreview(workspaceId) {
             groupId: e.groupId ?? -1,
             mark: e.mark || null,
             note: e.note || null,
+            ghostIdentityId: e.ghostIdentityId || null,
         })),
         groups: (ws.groups || []),
     };
@@ -193,7 +214,20 @@ async function openWorkspace(workspaceId, inNewWindow = false) {
     const createdTabs = [];
     for (const entry of entries) {
         try {
-            const tab = await chrome.tabs.create({ url: entry.url, active: false, windowId });
+            let tab;
+            if (entry.ghostIdentityId && chrome.ghostPublicAPI?.openTab) {
+                tab = await new Promise((resolve, reject) => {
+                    chrome.ghostPublicAPI.openTab(
+                        { url: entry.url, identity: entry.ghostIdentityId, active: false },
+                        (t) => {
+                            if (chrome.runtime.lastError) reject(chrome.runtime.lastError);
+                            else resolve(t);
+                        }
+                    );
+                });
+            } else {
+                tab = await chrome.tabs.create({ url: entry.url, active: false, windowId });
+            }
             createdTabs.push(tab);
         } catch {
             createdTabs.push(null);
@@ -378,17 +412,134 @@ chrome.commands.onCommand.addListener(async (command) => {
 });
 
 // ============================================================
+// Persistent tab hierarchy (survives browser restarts)
+// ============================================================
+
+// Converts the live tabId-based map to URL+index pairs and saves to local storage.
+// Called whenever tabParentMap changes in session storage.
+// Writes the current tab hierarchy to local storage as URL+index pairs.
+// This is called from onCreated to capture naturally-opened child tabs
+// (cmd+click etc.).  It NEVER deletes the backup — deletion is handled
+// exclusively by Initializer._saveHierarchy when the user explicitly
+// removes all hierarchy relationships.  Keeping writes additive-only
+// ensures the backup survives browser shutdown (where onRemoved fires
+// for every tab and would otherwise progressively empty the session and
+// trigger a spurious delete).
+async function saveHierarchy() {
+    try {
+        const { tabParentMap = {} } = await chrome.storage.session.get('tabParentMap');
+        if (!Object.keys(tabParentMap).length) return;
+
+        const tabs = await chrome.tabs.query({});
+        const tabById = {};
+        for (const tab of tabs) tabById[tab.id] = tab;
+
+        const entries = [];
+        for (const [tabIdStr, parentTabId] of Object.entries(tabParentMap)) {
+            const tab = tabById[Number(tabIdStr)];
+            const parentTab = tabById[parentTabId];
+            if (!tab || !parentTab) continue;
+            // Skip system pages (chrome://, edge://, about:) and tabs whose URL
+            // hasn't loaded yet (empty string).
+            // Only skip entries where the child has no matchable URL.
+            // Parent may be a system page (chrome://extensions/, ghost://extensions)
+            // — if it is open on restore the relationship will be recovered.
+            if (isSystemUrl(tab.url)) continue;
+            entries.push({
+                url: normalizeUrl(tab.url),
+                index: tab.index,
+                parentUrl: normalizeUrl(parentTab.url),
+                parentIndex: parentTab.index,
+                ghostIdentityId: tab.ghostPublicAPI?.identity_id ?? null,
+                parentGhostIdentityId: parentTab.ghostPublicAPI?.identity_id ?? null,
+            });
+        }
+
+        if (entries.length > 0) {
+            await chrome.storage.local.set({ tabHierarchy: entries });
+        }
+    } catch (e) {
+        console.error('[Hierarchy] save failed:', e);
+    }
+}
+
+// On browser startup, tab IDs are reassigned. Match saved URL+index pairs to
+// the newly restored tabs and rebuild tabParentMap in session storage.
+async function restoreHierarchy() {
+    try {
+        const { tabHierarchy: entries } = await chrome.storage.local.get('tabHierarchy');
+        if (!Array.isArray(entries) || !entries.length) return;
+
+        const tabs = await chrome.tabs.query({});
+        const realTabs = tabs.filter(t => !isSystemUrl(t.url));
+
+        // Child lookup: only non-system tabs.
+        // Parent lookup: all tabs with a URL (system pages like chrome://extensions/
+        // or ghost://extensions can be valid parents if they are currently open).
+        const tabsByUrl = {};
+        const parentByUrl = {};
+        for (const tab of realTabs) {
+            const key = normalizeUrl(tab.url);
+            if (!tabsByUrl[key]) tabsByUrl[key] = [];
+            tabsByUrl[key].push(tab);
+        }
+        for (const tab of tabs) {
+            if (!tab.url) continue;
+            const key = normalizeUrl(tab.url);
+            if (!parentByUrl[key]) parentByUrl[key] = [];
+            parentByUrl[key].push(tab);
+        }
+
+        // Pick the candidate whose index is closest to the saved index
+        const bestMatch = (candidates, savedIndex) =>
+            candidates.reduce((best, tab) =>
+                Math.abs(tab.index - savedIndex) < Math.abs(best.index - savedIndex) ? tab : best
+            );
+
+        const tabParentMap = {};
+        for (const entry of entries) {
+            const childCandidates = tabsByUrl[normalizeUrl(entry.url)];
+            const parentCandidates = parentByUrl[normalizeUrl(entry.parentUrl)];
+            if (!childCandidates?.length || !parentCandidates?.length) continue;
+
+            const childTab = bestMatch(childCandidates, entry.index);
+            const parentTab = bestMatch(parentCandidates, entry.parentIndex);
+            if (childTab.id !== parentTab.id) {
+                tabParentMap[childTab.id] = parentTab.id;
+            }
+        }
+
+        if (Object.keys(tabParentMap).length > 0) {
+            await chrome.storage.session.set({ tabParentMap });
+        }
+    } catch (e) {
+        console.error('[Hierarchy] restore failed:', e);
+    }
+}
+
+// Restore on every browser launch (belt-and-suspenders alongside Initializer restore)
+chrome.runtime.onStartup.addListener(() => {
+    restoreHierarchy();
+});
+
+// ============================================================
 // Tab parent tracking
 // ============================================================
 
 chrome.tabs.onCreated.addListener((tab) => {
-    if (!isNewTabUrl(tab.url) && tab.openerTabId !== undefined) {
+    if (tab.openerTabId === undefined) return;
+    // Look up the opener to make sure it's a real page, not a system page.
+    // Tabs opened from chrome://, edge://, about: or with no URL yet should not
+    // be recorded as children — those relationships are noise, not hierarchy.
+    chrome.tabs.get(tab.openerTabId, (openerTab) => {
+        if (chrome.runtime.lastError) return;
+        if (isSystemUrl(openerTab.url)) return;
         chrome.storage.session.get(['tabParentMap'], (ret) => {
             let tabParentMap = ret.tabParentMap || {};
             tabParentMap[tab.id] = tab.openerTabId;
-            chrome.storage.session.set({ tabParentMap });
+            chrome.storage.session.set({ tabParentMap }, () => saveHierarchy());
         });
-    }
+    });
 });
 
 chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
@@ -404,6 +555,13 @@ chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
 });
 
 chrome.tabs.onRemoved.addListener((tabId) => {
+    // Only update session — do NOT call saveHierarchy() here.
+    // During browser shutdown onRemoved fires for every tab, progressively
+    // emptying the session map.  Calling saveHierarchy() after each removal
+    // would eventually write an empty map and delete the local backup right
+    // before the browser exits.  Initializer._saveHierarchy (triggered by
+    // getTree() on tab-change events) keeps the local backup accurate during
+    // normal use without this risk.
     chrome.storage.session.get(['tabParentMap'], (ret) => {
         let tabParentMap = ret.tabParentMap || {};
         delete tabParentMap[tabId];

--- a/src/components/DraggableTabItem.jsx
+++ b/src/components/DraggableTabItem.jsx
@@ -20,6 +20,7 @@ import {
 import HighlightLabel from './HighlightLabel';
 import { DragItemTypes } from '../util/DragDropConstants';
 import { t } from '../util/i18n';
+import { getIdentityColor } from '../util/ghostCompat';
 
 /**
  * Collapse indicator badge - shows children count when collapsed
@@ -35,6 +36,14 @@ const CollapsedBadge = memo(({ count }) => {
 
 CollapsedBadge.displayName = 'CollapsedBadge';
 
+const isSafeFaviconUrl = (url) => {
+    try {
+        return /^https?:\/\//.test(url);
+    } catch {
+        return false;
+    }
+};
+
 /**
  * Tab item icon component
  */
@@ -43,7 +52,7 @@ const TabItemIcon = memo(({ tab }) => {
         return <LoadingOutlined className="front-icon" />;
     }
 
-    if (tab.favIconUrl) {
+    if (tab.favIconUrl && isSafeFaviconUrl(tab.favIconUrl)) {
         return <img src={tab.favIconUrl} alt="" />;
     }
 
@@ -1034,6 +1043,208 @@ export const GroupContainerItem = memo(({
 });
 
 GroupContainerItem.displayName = 'GroupContainerItem';
+
+const IDENTITY_COLOR_PRESETS = [
+    '#e53935',
+    '#e91e63',
+    '#9c27b0',
+    '#2196f3',
+    '#009688',
+    '#4caf50',
+    '#ff9800',
+    '#795548',
+];
+
+/**
+ * Ghost Identity Container Item - collapsible header grouping all tabs
+ * belonging to one Ghost Browser identity. Double-click to rename.
+ */
+export const GhostIdentityContainerItem = memo(({
+    node,
+    ghostIdentityInfo,
+    isCollapsed,
+    onToggleCollapse,
+    onIdentityRename,
+    onIdentityColorChange,
+    onGroupEditingChange,
+    children,
+}) => {
+    const { id, name, isTemporary, tabCount } = ghostIdentityInfo;
+    const displayColor = ghostIdentityInfo.color || getIdentityColor(id);
+    const tabId = node.tab.id;
+
+    const [editing, setEditing] = useState(false);
+    const [editName, setEditName] = useState(name);
+    const [editColor, setEditColor] = useState(ghostIdentityInfo.color || '');
+    const inputRef = useRef(null);
+    const editorRef = useRef(null);
+
+    const collapsedIcons = useMemo(() => {
+        if (!isCollapsed) return [];
+        const icons = [];
+        const collect = (n) => {
+            if (icons.length >= 8) return;
+            if (n.tab && !n.tab.isGroup && !n.tab.isGhostIdentity) {
+                icons.push({ id: n.tab.id, favIconUrl: n.tab.favIconUrl, url: n.tab.url });
+            }
+            if (n.children) n.children.forEach(collect);
+        };
+        if (node.children) node.children.forEach(collect);
+        return icons;
+    }, [isCollapsed, node]);
+
+    const hiddenIconCount = useMemo(() => {
+        if (!isCollapsed) return 0;
+        let total = 0;
+        const count = (n) => {
+            if (n.tab && !n.tab.isGroup && !n.tab.isGhostIdentity) total++;
+            if (n.children) n.children.forEach(count);
+        };
+        if (node.children) node.children.forEach(count);
+        return Math.max(0, total - 8);
+    }, [isCollapsed, node]);
+
+    const commitEdit = useCallback(() => {
+        setEditing(false);
+        onGroupEditingChange?.(false);
+        const trimmed = editName.trim();
+        if (trimmed && trimmed !== name) {
+            onIdentityRename?.(id, trimmed);
+        }
+        const initialColor = ghostIdentityInfo.color || '';
+        if (editColor !== initialColor) {
+            onIdentityColorChange?.(id, editColor || null);
+        }
+    }, [editName, editColor, name, id, ghostIdentityInfo, onIdentityRename, onIdentityColorChange, onGroupEditingChange]);
+
+    const cancelEdit = useCallback(() => {
+        setEditing(false);
+        onGroupEditingChange?.(false);
+        setEditName(name);
+        setEditColor(ghostIdentityInfo.color || '');
+    }, [name, ghostIdentityInfo, onGroupEditingChange]);
+
+    const enterEdit = useCallback((e) => {
+        e.stopPropagation();
+        setEditName(name);
+        setEditColor(ghostIdentityInfo.color || '');
+        setEditing(true);
+        onGroupEditingChange?.(true);
+    }, [name, ghostIdentityInfo, onGroupEditingChange]);
+
+    useEffect(() => {
+        if (editing && inputRef.current) {
+            inputRef.current.focus();
+            inputRef.current.select();
+        }
+    }, [editing]);
+
+    useEffect(() => {
+        if (!editing) return;
+        const handleClickOutside = (e) => {
+            if (editorRef.current && !editorRef.current.contains(e.target)) {
+                commitEdit();
+            }
+        };
+        document.addEventListener('mousedown', handleClickOutside);
+        return () => document.removeEventListener('mousedown', handleClickOutside);
+    }, [editing, commitEdit]);
+
+    const handleKeyDown = useCallback((e) => {
+        if (e.key === 'Enter') commitEdit();
+        else if (e.key === 'Escape') cancelEdit();
+    }, [commitEdit, cancelEdit]);
+
+    const handleClick = useCallback(() => {
+        if (editing) return;
+        onToggleCollapse?.(tabId);
+    }, [onToggleCollapse, tabId, editing]);
+
+    const handleChevronClick = useCallback((e) => {
+        e.stopPropagation();
+        onToggleCollapse?.(tabId);
+    }, [onToggleCollapse, tabId]);
+
+    const activeColor = editing ? (editColor || displayColor) : displayColor;
+    const dotStyle = useMemo(() => ({ backgroundColor: activeColor }), [activeColor]);
+    const containerStyle = useMemo(() => ({ borderLeftColor: activeColor }), [activeColor]);
+    const childrenStyle = useMemo(() => ({ borderLeftColor: activeColor }), [activeColor]);
+
+    return (
+        <div className="fake-li group-container-li ghost-identity-container-li">
+            <div
+                className={`group-container ghost-identity-container${isCollapsed ? ' collapsed' : ''}${editing ? ' editing' : ''}`}
+                style={containerStyle}
+                onClick={handleClick}
+                onDoubleClick={enterEdit}
+            >
+                {editing ? (
+                    <div className="group-editor" ref={editorRef} onClick={e => e.stopPropagation()}>
+                        <div className="group-editor-row">
+                            <span className="group-dot ghost-identity-dot" style={dotStyle} />
+                            <input
+                                ref={inputRef}
+                                className="group-title-input"
+                                value={editName}
+                                onChange={e => setEditName(e.target.value)}
+                                onKeyDown={handleKeyDown}
+                                placeholder="Identity name"
+                            />
+                            <button className="ghost-identity-save-btn" onClick={commitEdit}>{t('save')}</button>
+                        </div>
+                        <div className="ghost-identity-color-picker">
+                            {IDENTITY_COLOR_PRESETS.map(presetColor => (
+                                <span
+                                    key={presetColor}
+                                    className={`ghost-identity-color-swatch${editColor === presetColor ? ' active' : ''}`}
+                                    style={{ backgroundColor: presetColor }}
+                                    onClick={() => setEditColor(presetColor)}
+                                />
+                            ))}
+                            <input
+                                type="color"
+                                className="ghost-identity-color-custom"
+                                value={editColor || displayColor}
+                                onChange={e => setEditColor(e.target.value)}
+                                title="Custom color"
+                            />
+                        </div>
+                    </div>
+                ) : (
+                    <>
+                        <span className="group-dot ghost-identity-dot" style={dotStyle} />
+                        <span className="group-title ghost-identity-title">
+                            {name}
+                            {isTemporary && <span className="ghost-identity-temp-label"> (temporary)</span>}
+                        </span>
+                        <span className="group-count">({tabCount})</span>
+                        {isCollapsed && collapsedIcons.length > 0 && (
+                            <span className="group-favicon-strip">
+                                {collapsedIcons.map(icon => (
+                                    <GroupFavicon key={icon.id} favIconUrl={icon.favIconUrl} url={icon.url} />
+                                ))}
+                                {hiddenIconCount > 0 && (
+                                    <span className="group-favicon-more">+{hiddenIconCount}</span>
+                                )}
+                            </span>
+                        )}
+                        <EditOutlined className="group-edit-icon" onClick={enterEdit} />
+                        <span className={`group-chevron${isCollapsed ? ' collapsed' : ''}`} onClick={handleChevronClick}>
+                            {isCollapsed ? '›' : '‹'}
+                        </span>
+                    </>
+                )}
+            </div>
+            {!isCollapsed && children && (
+                <div className="group-children" style={childrenStyle}>
+                    {children}
+                </div>
+            )}
+        </div>
+    );
+});
+
+GhostIdentityContainerItem.displayName = 'GhostIdentityContainerItem';
 
 // Named exports for sub-components
 export { TabItemIcon, TabItemTitle, TabItemUrl, TabItemControl };

--- a/src/components/TabTree.jsx
+++ b/src/components/TabTree.jsx
@@ -21,6 +21,7 @@ import PermissionBanner from './PermissionBanner';
 import ContextMenu, { useContextMenu } from './ContextMenu';
 import SettingsView from './SettingsView';
 import { t } from '../util/i18n';
+import { isGhostBrowser, createTabCompat, getIdentityColor } from '../util/ghostCompat';
 
 const MAX_SHOW_BOOKMARK_COUNT = 30;
 
@@ -226,11 +227,13 @@ const useTabData = (initializer, chrome) => {
         return bookmarks;
     }, []);
 
-    const refreshRootNode = useCallback(async (searchKeyword = undefined) => {
+    const ghostIdentityFilterRef = useRef(null);
+
+    const refreshRootNode = useCallback(async (searchKeyword = undefined, ghostIdentityFilter = ghostIdentityFilterRef.current) => {
         try {
             const hasKeyword = searchKeyword && searchKeyword.length > 0;
             const [newRootNode, activeTab, bookmarks] = await Promise.all([
-                initializer.getTree(searchKeyword),
+                initializer.getTree(searchKeyword, ghostIdentityFilter),
                 initializer.getActiveTab(),
                 hasKeyword
                     ? initializer.getBookmarks(searchKeyword)
@@ -259,7 +262,7 @@ const useTabData = (initializer, chrome) => {
             clearTimeout(refreshTimerRef.current);
         }
         refreshTimerRef.current = setTimeout(() => {
-            refreshRootNode(keywordRef.current);
+            refreshRootNode(keywordRef.current, ghostIdentityFilterRef.current);
             refreshTimerRef.current = null;
         }, 150);
     }, [refreshRootNode]);
@@ -342,6 +345,7 @@ const useTabData = (initializer, chrome) => {
         keyword,
         setKeyword,
         refreshRootNode,
+        ghostIdentityFilterRef,
     };
 };
 
@@ -369,7 +373,10 @@ export default function TabTree({ chrome, initializer, panelMode = 'popup' }) {
         keyword,
         setKeyword,
         refreshRootNode,
+        ghostIdentityFilterRef,
     } = useTabData(initializer, chrome);
+
+    const [ghostIdentityFilter, setGhostIdentityFilter] = useState(null);
 
     // Collapsed tabs state - stores Set of collapsed tab IDs
     const [collapsedTabs, setCollapsedTabs] = useState(new Set());
@@ -439,8 +446,8 @@ export default function TabTree({ chrome, initializer, panelMode = 'popup' }) {
         if (!query || query.trim() === '') return;
         const encodedQuery = encodeURIComponent(query);
         const url = `https://www.google.com/search?q=${encodedQuery}`;
-        chrome.tabs.create({ url });
-    }, [chrome.tabs]);
+        createTabCompat(chrome, { url, identity: selectedTab?.ghostIdentityId ?? undefined });
+    }, [chrome, selectedTab]);
 
     // Handle tab click
     const onContainerClick = useCallback((tab) => {
@@ -449,7 +456,7 @@ export default function TabTree({ chrome, initializer, panelMode = 'popup' }) {
         if (noTabSelected) {
             searchByGoogle(keyword);
         } else if (tab.isBookmark) {
-            chrome.tabs.create({ url: tab.url });
+            createTabCompat(chrome, { url: tab.url, identity: selectedTab?.ghostIdentityId ?? undefined });
         } else if (tab.isGoogleSearch) {
             searchByGoogle(tab.title);
         } else {
@@ -457,9 +464,9 @@ export default function TabTree({ chrome, initializer, panelMode = 'popup' }) {
         }
         // Close the overlay if running inside one
         if (window.parent !== window) {
-            window.parent.postMessage({ type: 'tst-close-overlay' }, '*');
+            window.parent.postMessage({ type: 'tst-close-overlay' }, window.location.origin);
         }
-    }, [chrome.tabs, keyword, searchByGoogle]);
+    }, [chrome, keyword, searchByGoogle, selectedTab]);
 
     // Handle close all tabs in a branch
     const onCloseAllTabs = useCallback((node) => {
@@ -539,12 +546,12 @@ export default function TabTree({ chrome, initializer, panelMode = 'popup' }) {
 
     const onAddTabToGroup = useCallback(async (groupId) => {
         try {
-            const tab = await chrome.tabs.create({});
+            const tab = await createTabCompat(chrome, { identity: selectedTab?.ghostIdentityId ?? undefined });
             await chrome.tabs.group({ tabIds: [tab.id], groupId });
         } catch (error) {
             console.error('Failed to add tab to group:', error);
         }
-    }, [chrome.tabs]);
+    }, [chrome, selectedTab]);
 
     // Handle drag and drop — moves subtree and updates parent/group relationships
     const onTabDrop = useCallback(async (draggedTabId, targetTabId, targetTab, dropPosition) => {
@@ -587,10 +594,9 @@ export default function TabTree({ chrome, initializer, panelMode = 'popup' }) {
                     let moveToIndex;
                     if (dropPosition === 'before') {
                         moveToIndex = targetIndex - 1;
-                    } else if (dropPosition === 'after') {
-                        moveToIndex = targetSubtreeMaxIndex;
                     } else {
-                        moveToIndex = targetIndex;
+                        // 'after' and 'inside' both place after the last tab in target's subtree
+                        moveToIndex = targetSubtreeMaxIndex;
                     }
                     for (const tabId of subtreeTabIds) {
                         await initializer.moveTab(tabId, moveToIndex);
@@ -600,10 +606,9 @@ export default function TabTree({ chrome, initializer, panelMode = 'popup' }) {
                     let baseIndex;
                     if (dropPosition === 'before') {
                         baseIndex = targetIndex;
-                    } else if (dropPosition === 'after') {
-                        baseIndex = targetSubtreeMaxIndex + 1;
                     } else {
-                        baseIndex = targetIndex + 1;
+                        // 'after' and 'inside' both place after the last tab in target's subtree
+                        baseIndex = targetSubtreeMaxIndex + 1;
                     }
                     for (let i = 0; i < subtreeTabIds.length; i++) {
                         await initializer.moveTab(subtreeTabIds[i], baseIndex + i);
@@ -632,6 +637,33 @@ export default function TabTree({ chrome, initializer, panelMode = 'popup' }) {
             console.error('Failed to update tab parent:', error);
         }
     }, [initializer, refreshRootNode, keyword, rootNode, chrome.tabs]);
+
+    const handleIdentityRename = useCallback(async (identityId, newName) => {
+        try {
+            await initializer.setCustomIdentityName(identityId, newName);
+            refreshRootNode(keyword, ghostIdentityFilterRef.current);
+        } catch (error) {
+            console.error('Failed to save identity name:', error);
+        }
+    }, [initializer, keyword, refreshRootNode, ghostIdentityFilterRef]);
+
+    const handleIdentityColorChange = useCallback(async (identityId, color) => {
+        try {
+            await initializer.setCustomIdentityColor(identityId, color);
+            refreshRootNode(keyword, ghostIdentityFilterRef.current);
+        } catch (error) {
+            console.error('Failed to save identity color:', error);
+        }
+    }, [initializer, keyword, refreshRootNode, ghostIdentityFilterRef]);
+
+    const handleGhostFilterToggle = useCallback(() => {
+        const targetIdentity = selectedTab?.ghostIdentityId ?? null;
+        if (!targetIdentity) return;
+        const newFilter = ghostIdentityFilterRef.current === targetIdentity ? null : targetIdentity;
+        ghostIdentityFilterRef.current = newFilter;
+        setGhostIdentityFilter(newFilter);
+        refreshRootNode(keyword, newFilter);
+    }, [ghostIdentityFilterRef, keyword, refreshRootNode, selectedTab]);
 
     // Keyboard navigation
     const { focusSearchField } = useKeyboardNavigation({
@@ -668,7 +700,7 @@ export default function TabTree({ chrome, initializer, panelMode = 'popup' }) {
 
     // Handle search text change
     const handleSearchChange = useCallback((e) => {
-        const normalizedKeyword = e.target.value.replace(/\\/g, '\\\\');
+        const normalizedKeyword = e.target.value;
         setKeyword(normalizedKeyword);
         refreshRootNode(normalizedKeyword);
     }, [setKeyword, refreshRootNode]);
@@ -777,7 +809,7 @@ export default function TabTree({ chrome, initializer, panelMode = 'popup' }) {
             {
                 icon: <PlusOutlined />,
                 label: t('newTab'),
-                onClick: () => chrome.tabs.create({}),
+                onClick: () => createTabCompat(chrome, { identity: selectedTab?.ghostIdentityId ?? undefined }),
             },
             { divider: true },
             {
@@ -875,6 +907,8 @@ export default function TabTree({ chrome, initializer, panelMode = 'popup' }) {
                     showUrls={showUrls}
                     onGroupContextMenu={isSidepanel ? handleGroupContextMenu : undefined}
                     onTabContextMenu={isSidepanel ? handleTabContextMenu : undefined}
+                    onIdentityRename={handleIdentityRename}
+                    onIdentityColorChange={handleIdentityColorChange}
                 />
 
                 {showBookmarks && (
@@ -925,9 +959,26 @@ export default function TabTree({ chrome, initializer, panelMode = 'popup' }) {
                         <button
                             className="filter-bar-btn"
                             title={t('newTab')}
-                            onClick={() => chrome.tabs.create({})}
+                            onClick={() => createTabCompat(chrome, { identity: selectedTab?.ghostIdentityId ?? undefined })}
                         >
                             <PlusOutlined />
+                        </button>
+                    )}
+                    {isGhostBrowser() && (
+                        <button
+                            className={`filter-bar-btn${ghostIdentityFilter ? ' active' : ''}`}
+                            title={ghostIdentityFilter ? 'Clear identity filter' : 'Filter by current identity'}
+                            onClick={handleGhostFilterToggle}
+                        >
+                            <span style={{
+                                display: 'inline-block',
+                                width: 10,
+                                height: 10,
+                                borderRadius: '50%',
+                                backgroundColor: ghostIdentityFilter
+                                    ? getIdentityColor(ghostIdentityFilter)
+                                    : (selectedTab?.ghostIdentityId ? getIdentityColor(selectedTab.ghostIdentityId) : '#888888'),
+                            }} />
                         </button>
                     )}
                 </div>

--- a/src/components/TabTreeView.jsx
+++ b/src/components/TabTreeView.jsx
@@ -1,5 +1,5 @@
 import { memo, useCallback } from 'react';
-import { DraggableTabItem, SearchItem, GroupContainerItem } from './DraggableTabItem';
+import { DraggableTabItem, SearchItem, GroupContainerItem, GhostIdentityContainerItem } from './DraggableTabItem';
 
 /**
  * Renders tree nodes recursively
@@ -19,6 +19,8 @@ const TreeNodeRenderer = memo(({
     onAddTabToGroup,
     onGroupContextMenu,
     onTabContextMenu,
+    onIdentityRename,
+    onIdentityColorChange,
     isTopLevel = true,
     panelMode = 'popup',
     onCloseTab,
@@ -53,6 +55,8 @@ const TreeNodeRenderer = memo(({
                 onAddTabToGroup={onAddTabToGroup}
                 onGroupContextMenu={onGroupContextMenu}
                 onTabContextMenu={onTabContextMenu}
+                onIdentityRename={onIdentityRename}
+                onIdentityColorChange={onIdentityColorChange}
                 isTopLevel={false}
                 panelMode={panelMode}
                 onCloseTab={onCloseTab}
@@ -63,9 +67,26 @@ const TreeNodeRenderer = memo(({
                 showUrls={showUrls}
             />
         ));
-    }, [keyword, selectedTabId, onContainerClick, onClosedButtonClick, onTabDrop, onTabItemSelected, collapsedTabs, onToggleCollapse, onGroupUpdate, onGroupEditingChange, onAddTabToGroup, onGroupContextMenu, onTabContextMenu, panelMode, onCloseTab, onMarkTab, tabMarks, onNoteTab, tabNotes, showUrls]);
+    }, [keyword, selectedTabId, onContainerClick, onClosedButtonClick, onTabDrop, onTabItemSelected, collapsedTabs, onToggleCollapse, onGroupUpdate, onGroupEditingChange, onAddTabToGroup, onGroupContextMenu, onTabContextMenu, onIdentityRename, onIdentityColorChange, panelMode, onCloseTab, onMarkTab, tabMarks, onNoteTab, tabNotes, showUrls]);
 
-    // Group container node
+    // Ghost identity container node
+    if (node.isIdentityNode()) {
+        return (
+            <GhostIdentityContainerItem
+                node={node}
+                ghostIdentityInfo={node.ghostIdentityInfo}
+                isCollapsed={isCollapsed}
+                onToggleCollapse={onToggleCollapse}
+                onIdentityRename={onIdentityRename}
+                onIdentityColorChange={onIdentityColorChange}
+                onGroupEditingChange={onGroupEditingChange}
+            >
+                {!isCollapsed && renderChildren(node)}
+            </GhostIdentityContainerItem>
+        );
+    }
+
+    // Chrome tab group container node
     if (node.isGroupNode()) {
         return (
             <GroupContainerItem
@@ -148,6 +169,8 @@ function TabTreeView({
     onAddTabToGroup,
     onGroupContextMenu,
     onTabContextMenu,
+    onIdentityRename,
+    onIdentityColorChange,
     panelMode = 'popup',
     onCloseTab,
     onMarkTab,
@@ -179,6 +202,8 @@ function TabTreeView({
                     onAddTabToGroup={onAddTabToGroup}
                     onGroupContextMenu={onGroupContextMenu}
                     onTabContextMenu={onTabContextMenu}
+                    onIdentityRename={onIdentityRename}
+                    onIdentityColorChange={onIdentityColorChange}
                     panelMode={panelMode}
                     onCloseTab={onCloseTab}
                     onMarkTab={onMarkTab}

--- a/src/index.css
+++ b/src/index.css
@@ -129,6 +129,10 @@ body[data-mode="sidepanel"] .outContainer {
   background-color: var(--hover-bg);
 }
 
+.filter-bar-btn.active {
+  background-color: var(--selected-bg-subtle);
+}
+
 /* TabItem Color */
 .fake-li .url {
   color: var(--text-muted);
@@ -395,6 +399,7 @@ body[data-mode="sidepanel"] .tabTreeViewContainer {
 
 .closeTabBtn {
   cursor: pointer;
+  -webkit-user-select: none;
   user-select: none;
   line-height: 1.8;
 }
@@ -478,6 +483,75 @@ body[data-mode="sidepanel"] .tabTreeViewContainer {
   margin: 3px;
   float: left;
   position: relative;
+}
+
+/* Ghost identity container reuses group-container styles */
+/* Override: circular dot instead of square */
+.ghost-identity-dot {
+  border-radius: 50% !important;
+  flex-shrink: 0;
+}
+
+.ghost-identity-temp-label {
+  font-size: 0.8em;
+  opacity: 0.6;
+  font-style: italic;
+}
+
+.ghost-identity-container .group-edit-icon {
+  margin-left: auto;
+}
+
+.ghost-identity-save-btn {
+  padding: 2px 8px;
+  font-size: 11px;
+  border: none;
+  border-radius: 3px;
+  background: var(--selected-bg);
+  color: #fff;
+  cursor: pointer;
+  flex-shrink: 0;
+  align-self: center;
+  margin-left: 4px;
+}
+
+.ghost-identity-save-btn:hover {
+  filter: brightness(1.15);
+}
+
+.ghost-identity-color-picker {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 6px;
+}
+
+.ghost-identity-color-swatch {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  border: 2px solid transparent;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.ghost-identity-color-swatch:hover {
+  transform: scale(1.2);
+}
+
+.ghost-identity-color-swatch.active {
+  border-color: var(--text-color, #333);
+}
+
+.ghost-identity-color-custom {
+  width: 22px;
+  height: 22px;
+  border: none;
+  border-radius: 50%;
+  padding: 0;
+  cursor: pointer;
+  background: none;
+  flex-shrink: 0;
 }
 
 /* Collapsed badge - shows children count when collapsed */
@@ -639,6 +713,7 @@ body[data-mode="sidepanel"] .tabTreeViewContainer {
   border-radius: 0 6px 6px 0;
   background-color: rgba(128, 128, 128, 0.08);
   cursor: pointer;
+  -webkit-user-select: none;
   user-select: none;
 }
 

--- a/src/util/Initializer.js
+++ b/src/util/Initializer.js
@@ -1,6 +1,7 @@
 import TabTreeNode from './TabTreeNode';
 import TabTreeGenerator from './TabTreeGenerator';
 import BookmarksTreeGenerator from './BookmarksTreeGenerator';
+import { getGhostIdentities, GHOST_DEFAULT_IDENTITY } from './ghostCompat';
 
 /**
  * Initializer - Chrome API wrapper for tabs, storage, and bookmarks
@@ -31,14 +32,198 @@ class Initializer {
         return activeTab ?? { id: -1 };
     }
 
+    _isSystemUrl(url) {
+        return !url || /^(chrome|edge|about):/.test(url);
+    }
+
+    // Normalise a URL for consistent hierarchy matching across sessions.
+    // Strips fragments (client-side state that changes between sessions) and,
+    // for non-http(s) URLs (internal browser pages like ghost://extensions),
+    // strips trailing slashes so "ghost://extensions" === "ghost://extensions/".
+    _normalizeUrl(url) {
+        if (!url) return url;
+        const noFrag = url.includes('#') ? url.slice(0, url.indexOf('#')) : url;
+        return /^https?:/.test(noFrag) ? noFrag : noFrag.replace(/\/$/, '');
+    }
+
+    // Converts the live tabId map to URL+index pairs and writes to local storage.
+    // Accepts pre-fetched tabs to avoid a redundant query when called from getTree().
+    async _saveHierarchy(tabParentMap, tabs = null) {
+        try {
+            if (!tabs) tabs = await this.getTabList();
+            const tabById = {};
+            for (const tab of tabs) tabById[tab.id] = tab;
+
+            const entries = [];
+            for (const [tabIdStr, parentTabId] of Object.entries(tabParentMap)) {
+                const tab = tabById[Number(tabIdStr)];
+                const parentTab = tabById[parentTabId];
+                if (!tab || !parentTab) continue;
+                // Only skip entries where the CHILD has no matchable URL (system pages,
+                // empty URLs).  Parent may be any URL including system pages such as
+                // chrome://extensions/ or ghost://extensions — if that tab is open on
+                // restore, the relationship will be recovered.
+                if (this._isSystemUrl(tab.url)) continue;
+                entries.push({
+                    url: this._normalizeUrl(tab.url),
+                    index: tab.index,
+                    parentUrl: this._normalizeUrl(parentTab.url),
+                    parentIndex: parentTab.index,
+                    ghostIdentityId: tab.ghostPublicAPI?.identity_id ?? null,
+                    parentGhostIdentityId: parentTab.ghostPublicAPI?.identity_id ?? null,
+                });
+            }
+
+            await new Promise((resolve) => {
+                if (entries.length > 0) {
+                    this.chrome.storage.local.set({ tabHierarchy: entries }, resolve);
+                } else {
+                    this.chrome.storage.local.remove('tabHierarchy', resolve);
+                }
+            });
+        } catch {}
+    }
+
+    // Restores hierarchy from local URL+index pairs into session tabParentMap.
+    // Accepts pre-fetched tabs to avoid a redundant query when called from getTree().
+    async _restoreHierarchy(tabs = null) {
+        try {
+            const ret = await new Promise((resolve) => {
+                this.chrome.storage.local.get(['tabHierarchy'], resolve);
+            });
+            const rawEntries = ret.tabHierarchy;
+            if (!Array.isArray(rawEntries) || !rawEntries.length) return {};
+            // Discard any legacy entries written before the child-URL filter was in
+            // place — they have empty or system child URLs and can never match a tab.
+            const entries = rawEntries.filter(e => !this._isSystemUrl(e.url));
+            if (!entries.length) return {};
+
+            if (!tabs) tabs = await this.getTabList();
+            const realTabs = tabs.filter(t => !this._isSystemUrl(t.url));
+
+            // Child candidates: only real (non-system) tabs — system-URL tabs can't be
+            // reliably matched as children since their URLs may not persist across restarts.
+            // Parent candidates: all tabs including system pages (chrome://extensions/,
+            // ghost://extensions, etc.) — if the parent tab is currently open it can be
+            // matched and the relationship restored.
+            const parentTabs = tabs.filter(t => !!t.url); // only skip truly empty URLs
+
+            const tabsByUrl = {};           // child lookup
+            const tabsByUrlAndIdentity = {}; // child lookup with identity
+            const parentByUrl = {};          // parent lookup (includes system pages)
+            const parentByUrlAndIdentity = {};
+
+            for (const tab of realTabs) {
+                const normUrl = this._normalizeUrl(tab.url);
+                if (!tabsByUrl[normUrl]) tabsByUrl[normUrl] = [];
+                tabsByUrl[normUrl].push(tab);
+                const identityKey = `${normUrl}::${tab.ghostPublicAPI?.identity_id ?? '__default__'}`;
+                if (!tabsByUrlAndIdentity[identityKey]) tabsByUrlAndIdentity[identityKey] = [];
+                tabsByUrlAndIdentity[identityKey].push(tab);
+            }
+
+            for (const tab of parentTabs) {
+                const normUrl = this._normalizeUrl(tab.url);
+                if (!parentByUrl[normUrl]) parentByUrl[normUrl] = [];
+                parentByUrl[normUrl].push(tab);
+                const identityKey = `${normUrl}::${tab.ghostPublicAPI?.identity_id ?? '__default__'}`;
+                if (!parentByUrlAndIdentity[identityKey]) parentByUrlAndIdentity[identityKey] = [];
+                parentByUrlAndIdentity[identityKey].push(tab);
+            }
+
+            const bestMatch = (candidates, savedIndex) =>
+                candidates.reduce((best, tab) =>
+                    Math.abs(tab.index - savedIndex) < Math.abs(best.index - savedIndex) ? tab : best
+                );
+
+            const tabParentMap = {};
+            for (const entry of entries) {
+                // Prefer identity-scoped lookup when the entry has ghost identity info
+                // (prevents a Default-identity tab from being matched to a non-Default tab
+                // that happens to share the same URL).
+                const entryHasIdentity = 'ghostIdentityId' in entry;
+                const eUrl = this._normalizeUrl(entry.url);
+                const ePUrl = this._normalizeUrl(entry.parentUrl);
+                const childCandidates = entryHasIdentity
+                    ? (tabsByUrlAndIdentity[`${eUrl}::${entry.ghostIdentityId ?? '__default__'}`] ?? tabsByUrl[eUrl])
+                    : tabsByUrl[eUrl];
+                const parentCandidates = entryHasIdentity
+                    ? (parentByUrlAndIdentity[`${ePUrl}::${entry.parentGhostIdentityId ?? '__default__'}`] ?? parentByUrl[ePUrl])
+                    : parentByUrl[ePUrl];
+                if (!childCandidates?.length || !parentCandidates?.length) continue;
+                const childTab = bestMatch(childCandidates, entry.index);
+                const parentTab = bestMatch(parentCandidates, entry.parentIndex);
+                if (childTab.id !== parentTab.id) {
+                    tabParentMap[childTab.id] = parentTab.id;
+                }
+            }
+
+            if (Object.keys(tabParentMap).length > 0) {
+                await new Promise((resolve) => {
+                    this.chrome.storage.session.set({ tabParentMap }, resolve);
+                });
+            }
+            return tabParentMap;
+        } catch {
+            return {};
+        }
+    }
+
+    // On first load after a browser restart the session flag 'hierarchyRestored' is absent.
+    // Ghost Browser fires onCreated with openerTabId during its restore pass, which puts
+    // wrong entries in session with new tab IDs that pass validation.  The flag lets us
+    // detect a fresh session and override session with our authoritative local backup
+    // before any of those entries can fool the validator.
+    //
+    // Additional wrinkle: Ghost Browser preserves chrome.storage.session across browser
+    // restarts (unlike plain Chrome, which clears it).  That means 'hierarchyRestored'
+    // can be true even though the browser restarted and tab IDs were all reassigned.
+    // We detect this by checking whether ANY session entry references a current tab ID.
+    // If the session has entries but NONE match current tabs it's a stale-session restart.
+    async _getValidatedMap(rawMap, tabs) {
+        const tabIdSet = new Set(tabs.map(t => t.id));
+        const rawEntries = Object.entries(rawMap);
+
+        const flagRet = await new Promise(resolve =>
+            this.chrome.storage.session.get(['hierarchyRestored'], resolve)
+        );
+        const alreadyRestored = flagRet.hierarchyRestored === true;
+
+        // Stale-session: had entries but none reference a tab that currently exists.
+        const sessionIsStale = rawEntries.length > 0 &&
+            !rawEntries.some(([k, v]) => tabIdSet.has(Number(k)) && tabIdSet.has(v));
+
+        if (!alreadyRestored || sessionIsStale) {
+            // Mark immediately so concurrent/re-entrant calls don't also restore.
+            this.chrome.storage.session.set({ hierarchyRestored: true });
+            // Pull local backup; if found it wins over whatever openerTabId put in session.
+            const restored = await this._restoreHierarchy(tabs);
+            if (Object.keys(restored).length > 0) {
+                return restored;
+            }
+            // No local backup — fall through and use whatever session has.
+        }
+
+        // Normal path: strip entries whose tab IDs no longer exist.
+        const validMap = {};
+        for (const [k, v] of rawEntries) {
+            if (tabIdSet.has(Number(k)) && tabIdSet.has(v)) {
+                validMap[Number(k)] = v;
+            }
+        }
+        if (Object.keys(validMap).length !== rawEntries.length) {
+            this.chrome.storage.session.set({ tabParentMap: validMap });
+        }
+        return validMap;
+    }
+
     /**
-     * Get tab parent relationships from storage
+     * Get tab parent relationships from storage (raw session read).
      */
     getTabParentMap() {
         return new Promise((resolve) => {
             this.chrome.storage.session.get(['tabParentMap'], (ret) => {
-                const tabParentMap = ret.tabParentMap || {};
-                resolve(tabParentMap);
+                resolve(ret.tabParentMap || {});
             });
         });
     }
@@ -48,7 +233,8 @@ class Initializer {
      */
     filterNodes(keyword, tabs) {
         try {
-            const regex = new RegExp(keyword, 'i');
+            const escaped = keyword.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+            const regex = new RegExp(escaped, 'i');
             return tabs.filter((tab) => regex.test(tab.title) || regex.test(tab.url));
         } catch {
             return tabs;
@@ -64,17 +250,108 @@ class Initializer {
 
     /**
      * Get the tab tree
+     * @param {string} [keyword] - Search keyword filter
+     * @param {string|null} [ghostIdentityFilter] - When set, only include tabs
+     *   whose ghostPublicAPI.identity_id matches this value (Ghost Browser only).
      */
-    async getTree(keyword = undefined) {
-        const tabParentMap = await this.getTabParentMap();
-        let tabs = await this.getTabList();
-        const tabGroups = await this.getTabGroups();
+    getCustomIdentityNames() {
+        return new Promise((resolve) => {
+            this.chrome.storage.local.get(['ghostIdentityNames'], (ret) => {
+                resolve(ret.ghostIdentityNames || {});
+            });
+        });
+    }
 
-        if (this.needFilterByKeyword(keyword)) {
-            tabs = this.filterNodes(keyword, tabs);
+    async setCustomIdentityName(identityId, name) {
+        const names = await this.getCustomIdentityNames();
+        if (name && name.trim()) {
+            names[identityId] = name.trim();
+        } else {
+            delete names[identityId];
+        }
+        return new Promise((resolve, reject) => {
+            this.chrome.storage.local.set({ ghostIdentityNames: names }, () => {
+                if (this.chrome.runtime.lastError) {
+                    reject(this.chrome.runtime.lastError);
+                } else {
+                    resolve();
+                }
+            });
+        });
+    }
+
+    getCustomIdentityColors() {
+        return new Promise((resolve) => {
+            this.chrome.storage.local.get(['ghostIdentityColors'], (ret) => {
+                resolve(ret.ghostIdentityColors || {});
+            });
+        });
+    }
+
+    async setCustomIdentityColor(identityId, color) {
+        const colors = await this.getCustomIdentityColors();
+        if (color) {
+            colors[identityId] = color;
+        } else {
+            delete colors[identityId];
+        }
+        return new Promise((resolve, reject) => {
+            this.chrome.storage.local.set({ ghostIdentityColors: colors }, () => {
+                if (this.chrome.runtime.lastError) {
+                    reject(this.chrome.runtime.lastError);
+                } else {
+                    resolve();
+                }
+            });
+        });
+    }
+
+    async getTree(keyword = undefined, ghostIdentityFilter = null) {
+        const [rawTabParentMap, tabs, tabGroups, apiIdentityMap, customNames, customColors] = await Promise.all([
+            this.getTabParentMap(),
+            this.getTabList(),
+            this.getTabGroups(),
+            getGhostIdentities(this.chrome),
+            this.getCustomIdentityNames(),
+            this.getCustomIdentityColors(),
+        ]);
+
+        // Validate session map with current tab IDs; restore from local if empty/stale.
+        const tabParentMap = await this._getValidatedMap(rawTabParentMap, tabs);
+
+        // Always persist so hierarchy survives the next restart.
+        if (Object.keys(tabParentMap).length > 0) {
+            this._saveHierarchy(tabParentMap, tabs);
         }
 
-        const treeGen = new TabTreeGenerator(tabs, tabParentMap, tabGroups);
+        // Merge API identity info with custom names and colors — custom values win
+        const identityInfoMap = { ...apiIdentityMap };
+        for (const [id, customName] of Object.entries(customNames)) {
+            identityInfoMap[id] = { ...(identityInfoMap[id] || { id, isTemporary: false }), name: customName };
+        }
+        for (const [id, customColor] of Object.entries(customColors)) {
+            identityInfoMap[id] = { ...(identityInfoMap[id] || { id, isTemporary: false }), color: customColor };
+        }
+
+        // Ensure the default identity always has a display name.
+        // Custom name (if set) was already merged above; fall back to "Default".
+        if (!identityInfoMap[GHOST_DEFAULT_IDENTITY]) {
+            identityInfoMap[GHOST_DEFAULT_IDENTITY] = { id: GHOST_DEFAULT_IDENTITY, name: 'Default', isTemporary: false };
+        }
+
+        let filteredTabs = tabs;
+
+        if (this.needFilterByKeyword(keyword)) {
+            filteredTabs = this.filterNodes(keyword, filteredTabs);
+        }
+
+        if (ghostIdentityFilter) {
+            filteredTabs = filteredTabs.filter(
+                (tab) => (tab.ghostPublicAPI?.identity_id ?? null) === ghostIdentityFilter
+            );
+        }
+
+        const treeGen = new TabTreeGenerator(filteredTabs, tabParentMap, tabGroups, identityInfoMap);
         return treeGen.getTree();
     }
 
@@ -139,6 +416,7 @@ class Initializer {
                     if (this.chrome.runtime.lastError) {
                         reject(this.chrome.runtime.lastError);
                     } else {
+                        this._saveHierarchy(tabParentMap);
                         resolve();
                     }
                 });

--- a/src/util/TabTreeGenerator.js
+++ b/src/util/TabTreeGenerator.js
@@ -1,4 +1,5 @@
 import TabTreeNode from './TabTreeNode';
+import { GHOST_DEFAULT_IDENTITY } from './ghostCompat';
 
 /**
  * TreeGenerator - Builds a tree structure from flat tab list.
@@ -6,10 +7,14 @@ import TabTreeNode from './TabTreeNode';
  * a tab only recognizes a parent in the same group (or both ungrouped).
  */
 class TreeGenerator {
-    constructor(tabs, tabParentMap, tabGroups = []) {
+    constructor(tabs, tabParentMap, tabGroups = [], identityInfoMap = {}) {
         this.tabs = tabs;
         this.tabParentMap = tabParentMap;
         this.tabGroups = tabGroups;
+        this.identityInfoMap = identityInfoMap;
+        // Ghost Browser is present if any tab has the ghostPublicAPI property.
+        // Used to assign the default-identity sentinel to tabs that lack it.
+        this.isGhostBrowser = tabs.some(t => t.ghostPublicAPI !== undefined);
         this.nodeMap = {};
         this.tabMap = {};
         this.rootNode = new TabTreeNode();
@@ -44,6 +49,9 @@ class TreeGenerator {
         if (this.tabGroups.length > 0) {
             this._wrapGroupNodes();
         }
+
+        // Step 3: Wrap root children by Ghost identity into collapsible identity containers
+        this._wrapIdentityNodes();
 
         return this.rootNode;
     }
@@ -138,12 +146,107 @@ class TreeGenerator {
         this.rootNode.children = newChildren;
     }
 
+    /**
+     * Get the Ghost identity ID for a root-level node.
+     * For group container nodes, use the identity of the first child tab.
+     * For regular tab nodes, use ghostIdentityId directly.
+     */
+    _getNodeIdentityId(node) {
+        if (node.tab?.isGroup) {
+            for (const child of (node.children || [])) {
+                const id = child.tab?.ghostIdentityId;
+                if (id) return id;
+            }
+            return null;
+        }
+        return node.tab?.ghostIdentityId ?? null;
+    }
+
+    /**
+     * Post-process: collect root-level children that share a Ghost identity
+     * into per-identity container nodes. Preserves first-appearance order;
+     * tabs with no identity are appended after all identity containers.
+     */
+    _wrapIdentityNodes() {
+        const oldChildren = this.rootNode.children;
+        const hasAny = oldChildren.some(c => this._getNodeIdentityId(c) !== null);
+        if (!hasAny) return;
+
+        const identityOrder = [];
+        const identityGroups = {};
+        const noIdentityChildren = [];
+
+        for (const child of oldChildren) {
+            const identityId = this._getNodeIdentityId(child);
+            if (identityId) {
+                if (!identityGroups[identityId]) {
+                    identityGroups[identityId] = [];
+                    identityOrder.push(identityId);
+                }
+                identityGroups[identityId].push(child);
+            } else {
+                noIdentityChildren.push(child);
+            }
+        }
+
+        const newChildren = [];
+        for (const identityId of identityOrder) {
+            const nodes = identityGroups[identityId];
+            const info = this.identityInfoMap[identityId];
+            const tabCount = nodes.reduce((sum, n) => sum + this._countTabs(n), 0);
+
+            const containerNode = new TabTreeNode();
+            containerNode.tab = {
+                id: `ghost-identity-${identityId}`,
+                title: info?.name || identityId,
+                isGhostIdentity: true,
+            };
+            containerNode.ghostIdentityInfo = {
+                id: identityId,
+                name: info?.name || identityId,
+                isTemporary: info?.isTemporary || false,
+                color: info?.color || null,
+                tabCount,
+            };
+            containerNode.parent = this.rootNode;
+
+            for (const node of nodes) {
+                node.parent = containerNode;
+                containerNode.children.push(node);
+            }
+            newChildren.push(containerNode);
+        }
+
+        this.rootNode.children = [...newChildren, ...noIdentityChildren];
+    }
+
+    _countTabs(node) {
+        let count = (node.tab && !node.tab.isGroup && !node.tab.isGhostIdentity) ? 1 : 0;
+        for (const child of (node.children || [])) {
+            count += this._countTabs(child);
+        }
+        return count;
+    }
+
     getNode(tab) {
         if (tab === undefined) {
             return this.rootNode;
         }
         if (!this.nodeMap[tab.id]) {
-            this.nodeMap[tab.id] = new TabTreeNode(tab);
+            // In Ghost Browser every tab gets a ghostIdentityId. Tabs with an
+            // explicit identity_id use that; tabs without one (default identity,
+            // or tabs where Ghost doesn't set ghostPublicAPI) get the sentinel.
+            // The || instead of ?? also handles the empty-string case.
+            let normalizedTab = tab;
+            if (this.isGhostBrowser) {
+                normalizedTab = {
+                    ...tab,
+                    ghostIdentityId:  tab.ghostPublicAPI?.identity_id  || GHOST_DEFAULT_IDENTITY,
+                    ghostWorkspaceId: tab.ghostPublicAPI?.workspace_id  ?? null,
+                    ghostIsTemporary: tab.ghostPublicAPI?.is_temporary_identity ?? false,
+                };
+            }
+            this.nodeMap[tab.id] = new TabTreeNode(normalizedTab);
         }
         return this.nodeMap[tab.id];
     }

--- a/src/util/TabTreeNode.js
+++ b/src/util/TabTreeNode.js
@@ -7,7 +7,8 @@ class TabTreeNode {
         this.children = children;
         this.parent = parent;
         this.isLeaf = true;
-        this.groupInfo = null; // { id, title, color, collapsed } for group container nodes
+        this.groupInfo = null;         // { id, title, color, collapsed } for Chrome tab group container nodes
+        this.ghostIdentityInfo = null; // { id, name, color, isTemporary, tabCount } for Ghost identity container nodes
     }
 
     /**
@@ -24,11 +25,16 @@ class TabTreeNode {
         });
         clonedNode.isLeaf = this.isLeaf;
         clonedNode.groupInfo = this.groupInfo ? { ...this.groupInfo } : null;
+        clonedNode.ghostIdentityInfo = this.ghostIdentityInfo ? { ...this.ghostIdentityInfo } : null;
         return clonedNode;
     }
 
     isGroupNode() {
         return this.groupInfo !== null;
+    }
+
+    isIdentityNode() {
+        return this.ghostIdentityInfo !== null;
     }
 
     hasParent() {
@@ -44,7 +50,7 @@ class TabTreeNode {
     }
 
     getAllTabIds() {
-        let tabIds = (this.tab && !this.groupInfo) ? [this.tab.id] : [];
+        let tabIds = (this.tab && !this.groupInfo && !this.ghostIdentityInfo) ? [this.tab.id] : [];
         if (this.children.length > 0) {
             this.children.forEach((child) => {
                 tabIds = tabIds.concat(child.getAllTabIds());

--- a/src/util/ghostCompat.js
+++ b/src/util/ghostCompat.js
@@ -1,0 +1,141 @@
+/**
+ * Ghost Browser compatibility helpers.
+ *
+ * Ghost Browser exposes `chrome.ghostPublicAPI` and per-tab `tab.ghostPublicAPI`.
+ * All functions here are no-ops / return null when running in plain Chrome/Chromium,
+ * so they are safe to call unconditionally throughout the codebase.
+ *
+ * Relevant Ghost APIs used:
+ *   tab.ghostPublicAPI.identity_id          – string identity ID for the tab
+ *   tab.ghostPublicAPI.workspace_id         – string workspace ID for the tab
+ *   tab.ghostPublicAPI.is_temporary_identity – boolean
+ *   chrome.ghostPublicAPI.openTab({ url, identity, index, active, pinned }, cb)
+ *   chrome.ghostPublicAPI.DEFAULT_IDENTITY
+ *   chrome.ghostPublicAPI.NEW_TEMPORARY_IDENTITY
+ */
+
+/**
+ * Sentinel identity ID used internally to represent the Ghost Browser default
+ * identity. Ghost Browser sets identity_id to null for default-identity tabs,
+ * so we normalise those to this constant so they can be grouped in the tree.
+ */
+export const GHOST_DEFAULT_IDENTITY = '__ghost_default__';
+
+/**
+ * Returns true when the extension is running inside Ghost Browser.
+ * Safe to call at any time; never throws.
+ */
+export function isGhostBrowser() {
+    try {
+        return typeof chrome !== 'undefined' && typeof chrome.ghostPublicAPI !== 'undefined';
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * Extract Ghost identity/workspace metadata from a raw Chrome tab object.
+ * Returns null fields in plain Chrome (no ghostPublicAPI on the tab).
+ *
+ * @param {chrome.tabs.Tab} tab
+ * @returns {{ identityId: string|null, workspaceId: string|null, isTemporary: boolean }}
+ */
+export function getGhostTabMeta(tab) {
+    if (!tab?.ghostPublicAPI) {
+        return { identityId: null, workspaceId: null, isTemporary: false };
+    }
+    return {
+        identityId: tab.ghostPublicAPI.identity_id ?? null,
+        workspaceId: tab.ghostPublicAPI.workspace_id ?? null,
+        isTemporary: tab.ghostPublicAPI.is_temporary_identity ?? false,
+    };
+}
+
+/**
+ * Create a tab, using Ghost's openTab API when an identity is provided.
+ * Falls through to chrome.tabs.create for all non-Ghost cases.
+ *
+ * Pass identity: null/undefined to skip Ghost even in Ghost Browser.
+ *
+ * @param {object} chromeApi  – The Chrome API instance (real or mock)
+ * @param {object} params
+ * @param {string}  [params.url]
+ * @param {string|null} [params.identity]  – Ghost identity ID; omit for standard creation
+ * @param {number}  [params.index]
+ * @param {boolean} [params.active]
+ * @param {boolean} [params.pinned]
+ * @param {number}  [params.windowId]
+ * @returns {Promise<chrome.tabs.Tab>}
+ */
+export async function createTabCompat(chromeApi, params) {
+    const { identity, ...rest } = params;
+
+    if (identity && chromeApi?.ghostPublicAPI?.openTab) {
+        return new Promise((resolve, reject) => {
+            const ghostParams = { identity };
+            if (rest.url !== undefined)    ghostParams.url    = rest.url;
+            if (rest.index !== undefined)  ghostParams.index  = rest.index;
+            if (rest.active !== undefined) ghostParams.active = rest.active;
+            if (rest.pinned !== undefined) ghostParams.pinned = rest.pinned;
+
+            chromeApi.ghostPublicAPI.openTab(ghostParams, (tab) => {
+                if (chromeApi.runtime?.lastError) {
+                    reject(chromeApi.runtime.lastError);
+                } else {
+                    resolve(tab);
+                }
+            });
+        });
+    }
+
+    return chromeApi.tabs.create(rest);
+}
+
+/**
+ * Fetch Ghost Browser identity info (name, isTemporary) for all known identities.
+ * Returns a map of identityId → { id, name, isTemporary }.
+ * Returns an empty object in plain Chrome or if the API is unavailable.
+ *
+ * @param {object} chromeApi
+ * @returns {Promise<Object.<string, { id: string, name: string, isTemporary: boolean }>>}
+ */
+export async function getGhostIdentities(chromeApi) {
+    if (!chromeApi?.ghostPublicAPI?.getIdentities) return {};
+    return new Promise((resolve) => {
+        try {
+            chromeApi.ghostPublicAPI.getIdentities((identities) => {
+                if (!Array.isArray(identities)) { resolve({}); return; }
+                const map = {};
+                for (const identity of identities) {
+                    if (identity?.id) {
+                        map[identity.id] = {
+                            id: identity.id,
+                            name: identity.name || identity.id,
+                            isTemporary: identity.isTemporary || false,
+                        };
+                    }
+                }
+                resolve(map);
+            });
+        } catch {
+            resolve({});
+        }
+    });
+}
+
+/**
+ * Generate a deterministic HSL color from an identity ID string.
+ * Ensures every unique identityId always maps to the same color for UI consistency.
+ *
+ * @param {string|null} identityId
+ * @returns {string} CSS color string
+ */
+export function getIdentityColor(identityId) {
+    if (!identityId) return '#888888';
+    let hash = 0;
+    for (let i = 0; i < identityId.length; i++) {
+        hash = (hash * 31 + identityId.charCodeAt(i)) | 0;
+    }
+    const hue = Math.abs(hash) % 360;
+    return `hsl(${hue}, 65%, 55%)`;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -10926,15 +10926,10 @@ yallist@^3.0.2:
   resolved "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
 
-yaml@^1.10.0, yaml@^1.10.2, yaml@^1.7.2:
+yaml@^1.10.0, yaml@^1.10.2, yaml@^1.7.2, yaml@^2.4.2:
   version "1.10.2"
   resolved "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
-
-yaml@^2.4.2:
-  version "2.8.2"
-  resolved "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz"
-  integrity sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==
 
 yargs-parser@^20.2.2:
   version "20.2.9"


### PR DESCRIPTION
## Summary

This branch adds several major features and improvements built on top of the v2 base:

### Ghost Browser Compatibility
- Full support for Ghost Browser's identity system — tabs are grouped into per-identity containers in the tree, each with a distinct color and collapsible header
- Identity filter button in the toolbar filters the tree to the current tab's identity
- Identity names and colors are customizable inline (custom values persist to local storage and override API values)
- Tab creation via `ghostPublicAPI.openTab` when an identity is active
- Tab hierarchy persistence correctly handles Ghost identity scoping — URL matches are identity-aware to prevent cross-identity collisions

### Persistent Tab Hierarchy (Survives Browser Restarts)
- Parent-child relationships are saved to `chrome.storage.local` as URL+index pairs on every change
- On startup, relationships are reconstructed by matching saved URLs to the newly restored tabs using closest-index matching
- Handles Ghost Browser's unique behavior of preserving `chrome.storage.session` across restarts (stale-session detection)
- Correctly handles system-URL parents (`chrome://extensions/`, `ghost://extensions`) and non-http URL normalization (fragment stripping, trailing slash normalization)
- Service worker `onRemoved` no longer triggers a hierarchy save (prevents shutdown-sequence deletion of the backup)

### Context Menu (Side Panel)
- Right-click context menu on tabs, groups, and empty area
- Tab actions: mark, add note, collapse/expand, close
- Group actions: new tab in group, edit, collapse/expand
- Empty area actions: new tab, save/view workspaces, settings, help

### Tab Notes
- Attach a short note (up to 30 chars) to any tab, displayed as a colored inline tag
- Notes support multiple colors and persist to `chrome.storage.local`
- Accessible via context menu or hover button

### Settings View
- New settings panel accessible from the toolbar
- Toggle to show/hide URLs under tab titles
- Link to configure keyboard shortcuts

### Drag & Drop Improvements
- Fixed drag-drop "after" case index calculation
- Tabs dropped **onto** a parent (inside/child drop) now insert at the **end** of the existing child list rather than the beginning

### Other
- Tab Groups permission banner for users who haven't granted the `tabGroups` permission
- Permission grant flow disabled in overlay (popup) mode
- Visual test suite expanded significantly (new screenshots for context menu, notes, settings, group editing)
- `.gitignore` updated to exclude additional build artifacts
